### PR TITLE
Added code for initial version of Only Markdown snippet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   python: python3.10
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -38,12 +39,15 @@ repos:
       # Run the formatter.
       - id: ruff-format
 
-  - repo: https://github.com/econchick/interrogate
+# --- MODIFIED SECTION ---
+  - repo: https://github.com/econchick/interrogate # Note: repo is econchick, not econchs as in traceback
     rev: 1.5.0
     hooks:
       - id: interrogate
         exclude: ^app/serve
         args: [--fail-under=80, --verbose]
+        additional_dependencies: [setuptools] # <--- ADD THIS LINE
+# --- END MODIFIED SECTION ---
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0

--- a/src/elevate/only_markdown.py
+++ b/src/elevate/only_markdown.py
@@ -1,0 +1,134 @@
+import re
+
+from dotenv import load_dotenv
+from litellm import completion
+
+# Load environment variables
+load_dotenv()
+
+
+class OnlyMarkdown:
+    """Class that only supports Markdown syntax."""
+
+    def __init__(self, with_model: str = "gemini/gemini-2.0-flash-lite") -> None:
+        """Initialize the OnlyMarkdown class"""
+        self.model = with_model
+
+    def make_llm_call(self, system_prompt: str, input_text: str) -> str:
+        """
+        Makes the LLM call using litellm, extracting the markdown content.
+        """
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": input_text},
+        ]
+
+        response = completion(model=self.model, messages=messages, temperature=0.1)
+        output = response.choices[0].message.content  # type: str
+        match = re.search(
+            r"```markdown\n([\s\S]*?)\n```", output
+        )  #  ([\s\S]*?) matches any character (including newlines)
+        if match:
+            return (
+                match.group(1).strip()
+            )  # group(1) is content and strip remove leading/trailing whitespaces
+
+        # Option 2:  Use Optional and handle the case in the caller (Cleaner):
+        return output
+
+    def get_conversion_system_prompt(self) -> str:
+        """
+        Return a system prompt to convert input text into Markdown syntax.
+        """
+        prompt_content = """ROLE:
+You are a highly skilled Markdown converter, specializing in transforming plain text into clean and accurate GitHub Flavored Markdown (GFM). Your sole purpose is to convert the provided input text into its equivalent Markdown representation.
+
+**Task:**
+
+Convert the given input text into GitHub Flavored Markdown.
+
+**Instructions:**
+
+1.  **Input:** You will receive a string of plain text as input.
+2.  **Conversion:**  Carefully analyze the input and apply the appropriate Markdown syntax to represent the text's structure, formatting, and content.  This includes, but is not limited to:
+    *   Headings (using `#`, `##`, `###`, etc.)
+    *   Emphasis (using `*`, `_`, `**`, `__`)
+    *   Lists (ordered and unordered)
+    *   Links (using `[text](url)`)
+    *   Images (using `![alt text](url)`)
+    *   Code blocks (using backticks ``` or indentation)
+    *   Inline code (using backticks ``)
+    *   Blockquotes (using `>`)
+    *   Tables (using pipes `|` and hyphens `-`)
+    *   Horizontal rules (using `---` or `***`)
+3.  **Output:**  Return ONLY the converted Markdown text.  Do NOT include any introductory phrases, explanations, or additional text beyond the Markdown representation of the input.  The output should be a single string.
+4.  **GitHub Flavored Markdown (GFM) Specifics:**  Adhere to GFM conventions. This includes, but is not limited to:
+    *   Using fenced code blocks with syntax highlighting (e.g., ```python)
+    *   Using task lists (e.g., `- [x] Completed task`)
+    *   Using tables with proper alignment.
+5.  **Accuracy:** Ensure the Markdown syntax is correct and renders as intended in a GitHub environment.
+6.  **Conciseness:**  Strive for the most concise and efficient Markdown representation possible.
+7.  **No Additional Information:**  Do NOT add any extra text, comments, or explanations. Only return the Markdown output.
+"""
+        return prompt_content
+
+    def get_summarization_system_prompt(self) -> str:
+        """
+        Return a system prompt to summarize and convert input text into Markdown syntax.
+        """
+        prompt_content = """ROLE:
+You are a highly skilled Markdown converter, specializing in transforming plain text into clean and accurate GitHub Flavored Markdown (GFM). You are also proficient at creating TL;DR summaries. Your task is to summarize the input text in TL;DR format *and* convert that summary into Markdown.
+
+**Tasks:**
+
+1.  **TL;DR Summary:** Create a concise "TL;DR" (Too Long; Didn't Read) summary of the input text.
+2.  **Markdown Conversion (of the TL;DR):** Convert *only the TL;DR summary* into GitHub Flavored Markdown.
+
+**Instructions:**
+
+1.  **Input:** You will receive a string of plain text as input.
+2.  **Process:**
+    *   Generate the TL;DR summary of the input text.
+    *   Convert the TL;DR summary *itself* into Markdown.
+3.  **Output:** Return ONLY the converted Markdown of the TL;DR summary. Do NOT include the original text or any other content.
+4.  **TL;DR Style:** The TL;DR should be concise, typically a few sentences, and convey the most important points of the original text.
+5.  **GitHub Flavored Markdown (GFM) Specifics:** Adhere to GFM conventions:
+    *   Using fenced code blocks with syntax highlighting (e.g., ```python) if appropriate for the summary.
+    *   Using lists (ordered or unordered) if the summary benefits from them.
+    *   Using emphasis (bold, italics) where needed.
+6.  **Accuracy:** Ensure the TL;DR summary is accurate and the resulting Markdown is correct and renders as intended in a GitHub environment.
+7.  **Conciseness:** Strive for the most concise and efficient representation.
+8.  **No Additional Information:**  Do NOT add any extra text, comments, or explanations. Only return the Markdown output of the TL;DR summary."""
+        return prompt_content
+
+    def convert_to_markdown(self, input_text: str) -> str:
+        """
+        Converts the given input text to GitHub Flavored Markdown (GFM) format.
+
+        This method retrieves the system prompt specifically designed for markdown conversion,
+        then uses it to make an LLM call to convert the input text.
+
+        Args:
+            input_text: The plain text to be converted to Markdown (string).
+
+        Returns:
+            The converted Markdown text (string).
+        """
+        system_prompt = self.get_conversion_system_prompt()  # Get the system prompt
+        return self.make_llm_call(system_prompt, input_text)
+
+    def summarize_and_convert_to_markdown(self, input_text: str) -> str:
+        """
+        Summarizes and Converts the given input text to GitHub Flavored Markdown (GFM) format.
+
+        This method retrieves the system prompt specifically designed to summarize and markdown conversion,
+        then uses it to make an LLM call to convert the input text.
+
+        Args:
+            input_text: The plain text to be converted to Markdown (string).
+
+        Returns:
+            The converted Markdown text (string).
+        """
+        system_prompt = self.get_summarization_system_prompt()  # Get the system prompt
+        return self.make_llm_call(system_prompt, input_text)

--- a/src/elevate/only_summary.py
+++ b/src/elevate/only_summary.py
@@ -1,0 +1,78 @@
+import re
+
+from dotenv import load_dotenv
+from litellm import completion
+
+# Load environment variables
+load_dotenv()
+
+
+class OnlySummary:
+    """Class that only returns summary in Markdown syntax."""
+
+    def __init__(self, with_model: str = "gemini/gemini-2.0-flash-lite") -> None:
+        """Initialize the OnlyMarkdown class"""
+        self.model = with_model
+
+    def make_llm_call(self, system_prompt: str, input_text: str) -> str:
+        """
+        Makes the LLM call using litellm, extracting the markdown content.
+        """
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": input_text},
+        ]
+
+        response = completion(model=self.model, messages=messages, temperature=0.1)
+        output = response.choices[0].message.content  # type: str
+        pattern = r"```markdown\n((?:(?!```).|\n)*?)```"
+        match = re.search(pattern, output, re.DOTALL)
+
+        if match:
+            return match.group(1).strip()
+        return output
+
+    def get_summarization_system_prompt(self) -> str:
+        """
+        Return a system prompt to summarize and convert input text into Markdown syntax.
+        """
+        prompt_content = """ROLE:
+You are a highly skilled Markdown converter, specializing in transforming plain text into clean and accurate GitHub Flavored Markdown (GFM). You are also proficient at creating TL;DR summaries. Your task is to summarize the input text in TL;DR format *and* convert that summary into Markdown.
+
+**Tasks:**
+
+1.  **TL;DR Summary:** Create a concise "TL;DR" (Too Long; Didn't Read) summary of the input text.
+2.  **Markdown Conversion (of the TL;DR):** Convert *only the TL;DR summary* into GitHub Flavored Markdown.
+
+**Instructions:**
+
+1.  **Input:** You will receive a string of plain text as input.
+2.  **Process:**
+    *   Generate the TL;DR summary of the input text.
+    *   Convert the TL;DR summary *itself* into Markdown.
+3.  **Output:** Return ONLY the converted Markdown of the TL;DR summary. Do NOT include the original text or any other content.
+4.  **TL;DR Style:** The TL;DR should be concise, typically a few sentences, and convey the most important points of the original text.
+5.  **GitHub Flavored Markdown (GFM) Specifics:** Adhere to GFM conventions:
+    *   Using fenced code blocks with syntax highlighting (e.g., ```python) if appropriate for the summary.
+    *   Using lists (ordered or unordered) if the summary benefits from them.
+    *   Using emphasis (bold, italics) where needed.
+6.  **Accuracy:** Ensure the TL;DR summary is accurate and the resulting Markdown is correct and renders as intended in a GitHub environment.
+7.  **Conciseness:** Strive for the most concise and efficient representation.
+8.  **No Additional Information:**  Do NOT add any extra text, comments, or explanations. Only return the Markdown output of the TL;DR summary."""
+        return prompt_content
+
+    def summarize_and_convert_to_markdown(self, input_text: str) -> str:
+        """
+        Summarizes and Converts the given input text to GitHub Flavored Markdown (GFM) format.
+
+        This method retrieves the system prompt specifically designed to summarize and markdown conversion,
+        then uses it to make an LLM call to convert the input text.
+
+        Args:
+            input_text: The plain text to be converted to Markdown (string).
+
+        Returns:
+            The converted Markdown text (string).
+        """
+        system_prompt = self.get_summarization_system_prompt()  # Get the system prompt
+        return self.make_llm_call(system_prompt, input_text)

--- a/tests/test_only_markdown.py
+++ b/tests/test_only_markdown.py
@@ -1,0 +1,53 @@
+from elevate.only_markdown import OnlyMarkdown
+
+input_text = """
+
+"""
+
+
+def test_simple_text_markdown_conversion() -> None:
+    """
+    Tests the conversion of simple text to Markdown format using the OnlyMarkdown class.
+
+    The test does *not* include assertions; it focuses on generating output
+    for manual inspection of the Markdown conversion.
+
+    Note: The test saves the output to "tests/only_markdown_sample_output.md".
+    """
+    content = input_text
+    only_markdown = OnlyMarkdown(with_model="gemini/gemini-2.0-flash-lite")
+    with open("tests/only_markdown_sample_output.md", "w") as file:
+        file.write(only_markdown.convert_to_markdown(content))
+
+
+# test_simple_text_markdown_conversion()
+
+
+def test_simple_text_summarization() -> None:
+    """
+    Tests the conversion of simple text to Markdown format using the OnlyMarkdown class.
+
+    The test does *not* include assertions; it focuses on generating output
+    for manual inspection of the Markdown conversion.
+
+    Note: The test saves the output to "tests/only_markdown_sample_output.md".
+    """
+    content = input_text
+    only_markdown = OnlyMarkdown(with_model="gemini/gemini-2.0-flash-lite")
+    with open("tests/only_markdown_sample_output.md", "w") as file:
+        file.write(only_markdown.summarize_and_convert_to_markdown(content))
+
+
+# test_simple_text_summarization()
+
+
+def test_information_from_an_article_markdown() -> None:
+    """Tests summarization of online article content into Markdown."""
+    # write code to read text from an article online and call text_simple_test_summarization function
+    pass
+
+
+def test_read_from_document_markdown() -> None:
+    """Tests summarization of document content into Markdown."""
+    # write code to read text from document and call text_simple_test_summarization function
+    pass

--- a/tests/test_only_markdown.py
+++ b/tests/test_only_markdown.py
@@ -1,7 +1,32 @@
+"""Module to test the text summarization functionality of the OnlySummary class."""
+
 from elevate.only_markdown import OnlyMarkdown
 
+# Sample input text
 input_text = """
+Repo for Learning - A Repository for Exploration
 
+This repository is designed to be a learning resource. It covers a variety of topics to help you expand your knowledge. This is a *great* place to start, and it's also **useful** for more experienced learners. You might even find some `inline code` examples!
+
+```
+def greet(name):
+    print(f"Hello, {name}!")
+
+greet("Learner")
+```
+See [link](https://www.wikipedia.org/) for more information.
+
+> This is a block quote.
+> It's used to highlight important information.
+
+Project Structure:
+
+|File/Directory | Description |
+
+| README.txt     | This file.  |
+| /examples      | Code examples. |
+
+This is the end of the README.
 """
 
 
@@ -11,43 +36,11 @@ def test_simple_text_markdown_conversion() -> None:
 
     The test does *not* include assertions; it focuses on generating output
     for manual inspection of the Markdown conversion.
-
-    Note: The test saves the output to "tests/only_markdown_sample_output.md".
     """
     content = input_text
     only_markdown = OnlyMarkdown(with_model="gemini/gemini-2.0-flash-lite")
-    with open("tests/only_markdown_sample_output.md", "w") as file:
-        file.write(only_markdown.convert_to_markdown(content))
+    markdown_output = only_markdown.convert_to_markdown(content)
+    print(markdown_output)
 
 
 # test_simple_text_markdown_conversion()
-
-
-def test_simple_text_summarization() -> None:
-    """
-    Tests the conversion of simple text to Markdown format using the OnlyMarkdown class.
-
-    The test does *not* include assertions; it focuses on generating output
-    for manual inspection of the Markdown conversion.
-
-    Note: The test saves the output to "tests/only_markdown_sample_output.md".
-    """
-    content = input_text
-    only_markdown = OnlyMarkdown(with_model="gemini/gemini-2.0-flash-lite")
-    with open("tests/only_markdown_sample_output.md", "w") as file:
-        file.write(only_markdown.summarize_and_convert_to_markdown(content))
-
-
-# test_simple_text_summarization()
-
-
-def test_information_from_an_article_markdown() -> None:
-    """Tests summarization of online article content into Markdown."""
-    # write code to read text from an article online and call text_simple_test_summarization function
-    pass
-
-
-def test_read_from_document_markdown() -> None:
-    """Tests summarization of document content into Markdown."""
-    # write code to read text from document and call text_simple_test_summarization function
-    pass

--- a/tests/test_only_summary.py
+++ b/tests/test_only_summary.py
@@ -1,0 +1,18 @@
+"""Module to test the text summarization functionality of the OnlySummary class."""
+
+from elevate.only_summary import OnlySummary
+
+input_text = """ """
+
+
+def test_simple_text_summarization() -> None:
+    """
+    Tests the summarization of simple text using the OnlySummary class.
+    """
+    content = input_text
+    only_summary_instance = OnlySummary(with_model="gemini/gemini-1.5-flash-latest")
+    summary_output = only_summary_instance.summarize_and_convert_to_markdown(content)
+    print(summary_output)
+
+
+# test_simple_text_summarization()


### PR DESCRIPTION
feat: Implement Only Markdown Conversion with Gemini LLM

This PR contains code for the functionality for converting plain text to Markdown.

Key changes:

*   Created `only_markdown.py`: Contains the `OnlyMarkdown` class, which handles LLM calls to generate Markdown output.  Uses Gemini as the LLM provider.
*   Created `test_only_markdown.py`: Includes unit tests for the Markdown conversion process. Tests two primary scenarios:
    *   Converting basic plain text to Markdown.
    *   Generating a TL;DR summary and converting it to Markdown.
* Added some test scenarios for reading online article and reading text from documents. They are yet to be implemented.
* Made change to python version in pre-commit.yaml