### PR TITLE
Added code for Only Rephrase snippet

### DIFF
--- a/src/elevate/only_rephrase.py
+++ b/src/elevate/only_rephrase.py
@@ -1,0 +1,55 @@
+from dotenv import load_dotenv
+from litellm import completion
+
+from elevate.only_rephrase_prompt import REPHRASE_PROMPT
+
+# Load environment variables
+load_dotenv()
+
+
+class OnlyRephrase:
+    """Class that returns rephrased text."""
+
+    def __init__(self, with_model: str = "gemini/gemini-2.0-flash-lite") -> None:
+        """Initialize the OnlyMarkdown class"""
+        self.model = with_model
+
+    def make_llm_call(self, system_prompt: str, input_text: str) -> str:
+        """
+        Makes the LLM call using litellm, extracting the markdown content.
+        """
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": input_text},
+        ]
+
+        response = completion(model=self.model, messages=messages, temperature=0.1)
+        output = str(response.choices[0].message.content)
+        return output
+
+    def get_rephrase_system_prompt(self) -> str:
+        """Returns the rephrase system prompt.
+
+        Returns:
+            str: A string containing the rephrase system prompt.
+        """
+        return REPHRASE_PROMPT
+
+    def rephrase_text(self, message: str, tone: str, length: str) -> str:
+        """Rephrases the given message with the specified tone and length.
+
+        Args:
+            message (str): The message to rephrase.
+            tone (str): The desired tone for the rephrased message.
+            length (str): The desired length for the rephrased message.
+
+        Returns:
+            str: The rephrased message.
+        """
+        system_prompt = self.get_rephrase_system_prompt()
+
+        message = "\n<Message>" + message + "</Message>\n\n"
+        message += "<Tone> " + tone + " </Tone>\n\n"
+        message += "<Length> " + length + " </Length>"
+
+        return self.make_llm_call(system_prompt, message)

--- a/src/elevate/only_rephrase_prompt.py
+++ b/src/elevate/only_rephrase_prompt.py
@@ -1,0 +1,29 @@
+REPHRASE_PROMPT = """
+You are a highly skilled expert in English grammar, style, and tone. Your primary task is to rephrase user-provided text to ensure it is grammatically correct, stylistically appropriate, and aligned with the specified tone and length.
+
+**INPUT**
+
+You will receive input in the following format:
+
+```
+<Message>The text to be rephrased.</Message>
+<Tone>The desired tone of the rephrased text (e.g., formal, informal, professional, friendly, humorous).</Tone>
+<Length>The desired length of the rephrased text (e.g., short, medium, long). Consider the original message's length when interpreting this. 'Short' should be shorter than the original, 'Long' should be longer, and 'Medium' should be roughly the same length.</Length>
+```
+
+**INSTRUCTIONS**
+
+1. **Grammatical Correctness:** Ensure the rephrased text is free of grammatical errors, including subject-verb agreement, tense consistency, correct punctuation, and proper sentence structure.
+2. **Stylistic Appropriateness:** Adjust the vocabulary and sentence structure to match the specified tone. For example, a formal tone should use sophisticated language and avoid contractions, while an informal tone can use simpler language and contractions.
+3. **Length Adjustment:** Modify the text to fit the specified length. If 'short' is specified, condense the text while preserving the core meaning. If 'long' is specified, elaborate on the text, providing more detail or examples. If 'medium' is specified, maintain a length similar to the original text.
+4. **Maintain Meaning:** Ensure the rephrased text retains the original meaning of the user-provided text. Do not add or remove information unless necessary to meet the length requirements.
+5. **Clarity and Coherence:** The rephrased text should be clear and easy to understand. Use appropriate transitions to ensure smooth flow between sentences.
+6. **Handle Ambiguity:** If the user-provided text is ambiguous, make a reasonable interpretation and rephrase accordingly. If necessary, add a brief clarification to the rephrased text.
+7. **Preserve Intent:** Understand the user's intent and ensure the rephrased text aligns with that intent. Consider the context of the message and the user's goals.
+
+
+**OUTPUT**
+
+Provide the rephrased text as a single string. Do not include any additional formatting or explanations.
+
+"""

--- a/tests/test_only_rephrase.py
+++ b/tests/test_only_rephrase.py
@@ -1,0 +1,99 @@
+"""Module to test the email generation functionalities of the OnlyEmail class."""
+
+from elevate.only_rephrase import OnlyRephrase
+
+
+def test_rephase_text_formal() -> None:
+    """
+    Test the rephrase_text method with a formal style.
+
+    This test case uses the OnlyRephrase class to rephrase an input message
+    with a formal style and a lengthy output. It then prints the rephrased text.
+    """
+    input_message = """
+    I need 2 days of sick leave.
+    """
+    only_rephrase = OnlyRephrase(with_model="gemini/gemini-2.0-flash-lite")
+    rephrased_text = only_rephrase.rephrase_text(input_message, "fomral", "lengthy")
+    print(rephrased_text)
+
+
+test_rephase_text_formal()
+
+
+def test_rephase_text_informal() -> None:
+    """
+    Test the rephrase_text method with a infformal style.
+
+    This test case uses the OnlyRephrase class to rephrase an input message
+    with a informal style and a short output. It then prints the rephrased text.
+    """
+    input_message = """
+    I need 2 days of sick leave.
+    """
+    only_rephrase = OnlyRephrase(with_model="gemini/gemini-2.0-flash-lite")
+    rephrased_text = only_rephrase.rephrase_text(input_message, "informal", "short")
+    print(rephrased_text)
+
+
+test_rephase_text_informal()
+
+
+def test_rephase_text_urgent() -> None:
+    """
+    Test the rephrase_text method with an urgent style.
+
+    This test case uses the OnlyRephrase class to rephrase an input message
+    with an urgent style and a lengthy output. It then prints the rephrased text.
+    """
+    input_message = """
+    This is a serious problem that needs to be addressed immediately.
+    """
+    only_rephrase = OnlyRephrase(with_model="gemini/gemini-2.0-flash-lite")
+    rephrased_text = only_rephrase.rephrase_text(input_message, "urgent", "lengthy")
+    print(rephrased_text)
+
+
+test_rephase_text_urgent()
+
+
+def test_rephase_text_enthusiastic() -> None:
+    """
+    Test the rephrase_text method with an enthusiastic style.
+
+    This test case uses the OnlyRephrase class to rephrase an input message
+    with an enthusiastic style and a medium output. It then prints the
+    rephrased text.
+    """
+    input_message = """
+    I'm so excited about this project!
+    """
+    only_rephrase = OnlyRephrase(with_model="gemini/gemini-2.0-flash-lite")
+    rephrased_text = only_rephrase.rephrase_text(
+        input_message, "enthusiastic", "medium"
+    )
+    print(rephrased_text)
+
+
+test_rephase_text_enthusiastic()
+
+
+def test_rephase_text_infromative() -> None:
+    """
+    Test the rephrase_text method with an informative style.
+
+    This test case uses the OnlyRephrase class to rephrase an input
+    message with an informative style and a lengthy output. It then
+    prints the rephrased text.
+    """
+    input_message = """
+    The system utilizes a multi-threaded architecture to improve performance..
+    """
+    only_rephrase = OnlyRephrase(with_model="gemini/gemini-2.0-flash-lite")
+    rephrased_text = only_rephrase.rephrase_text(
+        input_message, "informative", "lengthy"
+    )
+    print(rephrased_text)
+
+
+test_rephase_text_infromative()


### PR DESCRIPTION
This PR introduces the "Only Rephrase" functionality, which allows the user's message to be rephrased by making a call to a Large Language Model (LLM).

Key changes include:

*   **`only_rephrase.py`:** Implements the core rephrasing logic by calling an LLM to rephrase the user's input.
*   **`only_rephrase_prompt.py`:** Defines the system prompt used to guide the LLM during the rephrasing process.
*   **`test_only_rephrase.py`:** Contains five test cases to ensure the `only_rephrase` snippet functions correctly under various scenarios.